### PR TITLE
v0.9.1 fix issue where stick events on gamepad never reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixijs-input-devices",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Reece Como <reece.como@gmail.com>",
   "authors": [
     "Reece Como <reece.como@gmail.com>"

--- a/src/lib/devices/__tests__/GamepadDevice.poll.test.ts
+++ b/src/lib/devices/__tests__/GamepadDevice.poll.test.ts
@@ -135,6 +135,30 @@ describe("GamepadDevice — poll & events", () =>
         expect(gamepad.button.LeftStickDown).toBe(true);
     });
 
+    it("releases both left-stick vertical directions when returning to neutral", () =>
+    {
+        const { source, gamepad } = makeGamepad();
+        const now = Date.now();
+
+        // Push up first to ensure mixed up/down transitions don't latch state.
+        (source.axes[Axis.LeftStickY] as any) = -0.7;
+        gamepad.update(source, now);
+        expect(gamepad.button.LeftStickUp).toBe(true);
+        expect(gamepad.button.LeftStickDown).toBe(false);
+
+        // Then push down.
+        (source.axes[Axis.LeftStickY] as any) = 0.7;
+        gamepad.update(source, now + 16);
+        expect(gamepad.button.LeftStickUp).toBe(false);
+        expect(gamepad.button.LeftStickDown).toBe(true);
+
+        // Return to neutral: both directions should reset.
+        (source.axes[Axis.LeftStickY] as any) = 0;
+        gamepad.update(source, now + 32);
+        expect(gamepad.button.LeftStickUp).toBe(false);
+        expect(gamepad.button.LeftStickDown).toBe(false);
+    });
+
     // ---- importBinds round-trip --------------------------------------
 
     it("importBinds round-trip restores binds identically", () =>

--- a/src/lib/devices/gamepads/GamepadDevice.ts
+++ b/src/lib/devices/gamepads/GamepadDevice.ts
@@ -533,45 +533,49 @@ export class GamepadDevice
         for (let a = 0; a < axisCount; a++)
         {
             const value = _scale(source.axes[a], joy.deadzone);
-            const axisCode = AxisCode[a * 2 + (value > 0 ? 1 : 0)];
+            const negativeAxisCode = AxisCode[a * 2];
+            const positiveAxisCode = AxisCode[a * 2 + 1];
+            const axisCode = value > 0 ? positiveAxisCode : negativeAxisCode;
+            const oppositeAxisCode = value > 0 ? negativeAxisCode : positiveAxisCode;
 
             if (Math.abs(value) < joy.pressThreshold)
             {
-                if (this.button[axisCode])
+                for (const releasedAxisCode of [negativeAxisCode, positiveAxisCode])
                 {
-                    // emit events
-                    if (this.options.emitEvents)
+                    if (this.button[releasedAxisCode])
                     {
-                        // check named bind events (O(1) via precomputed index)
-                        const upNames = this._bindIndex.get(axisCode);
-
-                        if (upNames)
+                        // emit events
+                        if (this.options.emitEvents)
                         {
-                            for (let n = 0; n < upNames.length; n++)
-                            {
-                                const bindName = upNames[n]! as IBind;
-                                const event: GamepadNamedBindEvent = {
-                                    device: this,
-                                    type: "axis",
-                                    axis: a as Axis,
-                                    axisCode,
-                                    name: bindName,
-                                    pressed: false,
-                                    value,
-                                };
+                            // check named bind events (O(1) via precomputed index)
+                            const upNames = this._bindIndex.get(releasedAxisCode);
 
-                                this._bindUpEmitter.emit(bindName, event);
-                                this._emitter.emit("bindup", event);
+                            if (upNames)
+                            {
+                                for (let n = 0; n < upNames.length; n++)
+                                {
+                                    const bindName = upNames[n]! as IBind;
+                                    const event: GamepadNamedBindEvent = {
+                                        device: this,
+                                        type: "axis",
+                                        axis: a as Axis,
+                                        axisCode: releasedAxisCode,
+                                        name: bindName,
+                                        pressed: false,
+                                        value,
+                                    };
+
+                                    this._bindUpEmitter.emit(bindName, event);
+                                    this._emitter.emit("bindup", event);
+                                }
                             }
                         }
-                    }
-                }
-                else
-                {
-                    this._debounces.delete(axisCode);
-                }
 
-                this.button[axisCode] = false;
+                        this.button[releasedAxisCode] = false;
+                    }
+
+                    this._debounces.delete(releasedAxisCode);
+                }
             }
             else
             {
@@ -583,6 +587,7 @@ export class GamepadDevice
                 }
 
                 this.button[axisCode] = true;
+                this.button[oppositeAxisCode] = false;
                 this.lastInteraction = now;
 
                 // emit events


### PR DESCRIPTION
Saw @supermoos implemented that great fix in #7.

Have just merged `v0.9.0` which caused Merge Conflicts so had Cursor quickly reinvestigate/rewrite the same fix and add a regression test case.

Bumping to `v0.9.1`.

Co-authored-by: supermoos <supermoos@gmail.com>
