### PR TITLE
v0.10.0 - backtrack, remove navigation tree caching/invalidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixijs-input-devices",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "author": "Reece Como <reece.como@gmail.com>",
   "authors": [
     "Reece Como <reece.como@gmail.com>"

--- a/src/lib/devices/__tests__/Navigation.test.ts
+++ b/src/lib/devices/__tests__/Navigation.test.ts
@@ -3,7 +3,6 @@ import { Bounds, Container, ContainerOptions } from "pixi.js";
 import { UINavigation } from "../../navigation/UINavigation";
 import { registerPixiJSNavigationMixin } from "../../../Container.mixin";
 import { InputDevice } from "../../InputDevice";
-import { getAllNavigatables, invalidateNavigatablesCache } from "../../navigation/Navigatable";
 
 beforeAll(() => registerPixiJSNavigationMixin(Container));
 
@@ -157,96 +156,3 @@ afterEach(() =>
     jest.useRealTimers();
 });
 
-// -------------------------------------------------------------------
-// Navigation cache tests
-// -------------------------------------------------------------------
-
-describe("getAllNavigatables cache", () =>
-{
-    beforeAll(() => registerPixiJSNavigationMixin(Container));
-
-    it("returns cached result for the same root on repeated calls", () =>
-    {
-        const root = new MockContainer();
-        const child = new MockContainer({ navigationMode: "always" });
-        root.addChild(child);
-
-        invalidateNavigatablesCache(root);
-
-        const first = getAllNavigatables(root);
-        const second = getAllNavigatables(root);
-
-        // Same array reference — no rebuild
-        expect(first).toBe(second);
-        expect(first).toContain(child);
-    });
-
-    it("invalidateNavigatablesCache(root) forces a fresh walk", () =>
-    {
-        const root = new MockContainer();
-        const child1 = new MockContainer({ navigationMode: "always" });
-        root.addChild(child1);
-
-        invalidateNavigatablesCache(root);
-        const before = getAllNavigatables(root);
-        expect(before.length).toBe(1);
-
-        // Add a new child — cache is stale until invalidated
-        const child2 = new MockContainer({ navigationMode: "always" });
-        root.addChild(child2);
-
-        invalidateNavigatablesCache(root);
-        const after = getAllNavigatables(root);
-
-        expect(after.length).toBe(2);
-        expect(after).not.toBe(before); // new array
-    });
-
-    it("invalidateNavigatablesCache() with no arg clears all roots", () =>
-    {
-        const rootA = new MockContainer();
-        const rootB = new MockContainer();
-        const child = new MockContainer({ navigationMode: "always" });
-
-        rootA.addChild(new MockContainer({ navigationMode: "always" }));
-        rootB.addChild(child);
-
-        invalidateNavigatablesCache();
-        getAllNavigatables(rootA);
-        getAllNavigatables(rootB);
-
-        // Now invalidate everything
-        invalidateNavigatablesCache();
-
-        // Both should rebuild on next call (no stale reference)
-        const a2 = getAllNavigatables(rootA);
-        const b2 = getAllNavigatables(rootB);
-
-        expect(a2.length).toBe(1);
-        expect(b2.length).toBe(1);
-    });
-
-    it("UINavigation.invalidateNavCache() invalidates the stage root", () =>
-    {
-        const stage = new MockContainer();
-        const nav1 = new MockContainer({ navigationMode: "always" });
-        stage.addChild(nav1);
-
-        UINavigation.enable(stage); // calls invalidateNavigatablesCache internally
-
-        const first = getAllNavigatables(stage);
-        expect(first).toContain(nav1);
-
-        // Add another child — cache is stale
-        const nav2 = new MockContainer({ navigationMode: "always" });
-        stage.addChild(nav2);
-
-        UINavigation.invalidateNavCache();
-
-        const second = getAllNavigatables(stage);
-        expect(second.length).toBe(2);
-        expect(second).toContain(nav2);
-
-        UINavigation.disable();
-    });
-});

--- a/src/lib/devices/__tests__/Navigation.test.ts
+++ b/src/lib/devices/__tests__/Navigation.test.ts
@@ -156,3 +156,161 @@ afterEach(() =>
     jest.useRealTimers();
 });
 
+describe("UINavigation spatial backtracking", () =>
+{
+    // Layout (all elements at y=0, spread along x-axis):
+    //   left(-200)   center(0)   right(200)
+    //
+    // Also includes `near` at x=10, which is spatially between center and right.
+    // This lets us verify that backtrack returns to `center` when navigating
+    // right from `center` to `right` and then back left — even though `near`
+    // would be the closest spatial candidate from `right`.
+
+    let stage: MockContainer;
+    let left: MockContainer;
+    let center: MockContainer;
+    let near: MockContainer;
+    let right: MockContainer;
+
+    beforeEach(() =>
+    {
+        stage = new MockContainer({ label: "stage" });
+        left = new MockContainer({ label: "left", navigationMode: "always", x: -200 });
+        center = new MockContainer({ label: "center", navigationMode: "always", x: 0, navigationPriority: 1 });
+        near = new MockContainer({ label: "near", navigationMode: "always", x: 100 });
+        right = new MockContainer({ label: "right", navigationMode: "always", x: 200 });
+
+        stage.addChild(left, center, near, right);
+        InputDevice.add(InputDevice.keyboard);
+        UINavigation.enable(stage);
+        UINavigation.autoFocus();
+
+        expect(UINavigation.focusTarget?.label).toBe("center");
+    });
+
+    afterEach(() =>
+    {
+        UINavigation.disable();
+    });
+
+    test("returns to the origin when navigating in reverse", () =>
+    {
+        // center → right (spatial skips `near` since it's much farther right in this layout)
+        // Actually, `near` at x=10 is closer than `right` at x=200, so center → near first.
+        // Navigate again from near → right.
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("near");
+
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("center"); // backtrack to center
+    });
+
+    test("backtracks differ from spatial when an element is between origin and destination", () =>
+    {
+        // Force focus to right so the backtrack source is center (skipping `near`).
+        // We do this by navigating: center → near (spatial) → right (spatial).
+        // Backtrack source after the second step is `near`, not `center`.
+        // So going left from `right` gives `near` (backtrack), not `center` (which is farther).
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("near");
+
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("right");
+
+        // Backtrack: returns to `near`, not `center`
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("near");
+    });
+
+    test("backtrack memory is consumed after one use", () =>
+    {
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);  // backtrack: near → center
+        // Backtrack consumed. Now navigate right again → spatial from center → near.
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("near");
+    });
+
+    test("clears on Activate", () =>
+    {
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near
+        InputDevice.emitBindDownUp("NavigateActivate", InputDevice.keyboard); // clears backtrack
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // near → right (spatial, not backtrack to center)
+        expect(UINavigation.focusTarget?.label).toBe("right");
+    });
+
+    test("clears on Back", () =>
+    {
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near
+        InputDevice.emitBindDownUp("NavigateBack", InputDevice.keyboard);  // clears backtrack + clears focus
+        UINavigation.setFocus(near, InputDevice.keyboard);                 // restore focus
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // near → right (spatial, not backtrack)
+        expect(UINavigation.focusTarget?.label).toBe("right");
+    });
+
+    test("clears on any other directional navigation", () =>
+    {
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near (store backtrack)
+        InputDevice.emitBindDownUp("NavigateDown", InputDevice.keyboard);  // no target below; clears backtrack
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);  // spatial from near → center (no backtrack)
+        expect(UINavigation.focusTarget?.label).toBe("center");
+        // If backtrack had NOT been cleared by NavigateDown, we would have gone to center (same here).
+        // Verify the backtrack WAS cleared: a second left from center should go to left, not loop.
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("left");
+    });
+
+    test("clears on pointer setFocus", () =>
+    {
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near (store backtrack)
+        UINavigation.setFocus(near);                                        // pointer focus clears backtrack
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // near → right (spatial, not backtrack to center)
+        expect(UINavigation.focusTarget?.label).toBe("right");
+    });
+
+    test("clears when pushResponder is called", () =>
+    {
+        const responder = new MockContainer({ label: "responder", eventMode: "static", x: 50 });
+        stage.addChild(responder);
+
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near (store backtrack)
+        UINavigation.pushResponder(responder);
+        UINavigation.popResponder();
+        // Backtrack cleared. From near, navigate left → spatial → center.
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("center");
+    });
+
+    test("clears when popResponder is called", () =>
+    {
+        const responder = new MockContainer({ label: "responder", eventMode: "static", x: 50 });
+        stage.addChild(responder);
+
+        UINavigation.pushResponder(responder);
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // responder → right (store backtrack)
+        expect(UINavigation.focusTarget?.label).toBe("center");
+        UINavigation.popResponder();
+
+        expect(UINavigation.focusTarget?.label).toBe("center");
+        // Backtrack cleared by popResponder. From near (where we were before responder), navigate left → center.
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);
+        expect(UINavigation.focusTarget?.label).toBe("left");
+    });
+
+    test("disabled when spatial.backtracking is false", () =>
+    {
+        UINavigation.options.spatial.backtracking = false;
+
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);  // spatial (not backtrack): near → center
+        // Without backtrack this still lands on center (spatial agrees here).
+        // Navigate right → near, right → right to confirm no backtrack state builds up.
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // center → near
+        InputDevice.emitBindDownUp("NavigateRight", InputDevice.keyboard); // near → right
+        InputDevice.emitBindDownUp("NavigateLeft", InputDevice.keyboard);  // spatial: right → near (not backtrack to near either)
+        expect(UINavigation.focusTarget?.label).toBe("near");
+
+        UINavigation.options.spatial.backtracking = true; // restore
+    });
+});
+

--- a/src/lib/navigation/Navigatable.ts
+++ b/src/lib/navigation/Navigatable.ts
@@ -9,6 +9,7 @@ export interface SpatialNavigationOptions
 {
     minimumDistance: number;
     directionAxisWeight: number;
+    backtracking: boolean;
 }
 
 interface NavigatableQueryOptions

--- a/src/lib/navigation/Navigatable.ts
+++ b/src/lib/navigation/Navigatable.ts
@@ -18,66 +18,15 @@ interface NavigatableQueryOptions
     spatial: SpatialNavigationOptions;
 }
 
-// ----- Navigatable cache -----
-
-/**
- * WeakMap cache: root Container -> flat list of navigatable descendants.
- *
- * The cache is invalidated by `invalidateNavigatablesCache()`.  Call it
- * whenever your UI hierarchy changes (children added/removed, visibility
- * toggled) so that the next spatial-navigation query reflects the new state.
- *
- * UINavigation calls this automatically on `enable`, `disable`,
- * `pushResponder` and `popResponder`.
- */
-let _navCache = new WeakMap<Container, NavigatableContainer[]>();
-
-/**
- * Invalidate the navigatable-list cache for a specific root (or the entire
- * cache when no argument is given).
- *
- * Call this after adding/removing navigatable children or changing their
- * `visible` property so the next directional-navigation query stays correct.
- */
-export function invalidateNavigatablesCache(root?: Container): void
-{
-    if (root !== undefined)
-    {
-        _navCache.delete(root);
-    }
-    else
-    {
-        _navCache = new WeakMap();
-    }
-}
-
 // ----- Core functions -----
 
-/**
- * @returns all navigatable containers in some container.
- *
- * Results are cached per-root; call `invalidateNavigatablesCache(root)` after
- * structural or visibility changes.
- */
+/** @returns all navigatable containers in some container. */
 export function getAllNavigatables(
     target: Container,
-    navigatables?: NavigatableContainer[]
+    navigatables: NavigatableContainer[] = []
 ): NavigatableContainer[]
 {
-    // When an accumulator is passed explicitly (e.g. recursive self-call)
-    // we bypass the cache so the caller controls the buffer.
-    if (navigatables !== undefined)
-    {
-        return _collectNavigatables(target, navigatables);
-    }
-
-    const cached = _navCache.get(target);
-    if (cached !== undefined) return cached;
-
-    const fresh = _collectNavigatables(target, []);
-    _navCache.set(target, fresh);
-
-    return fresh;
+    return _collectNavigatables(target, navigatables);
 }
 
 function _collectNavigatables(

--- a/src/lib/navigation/UINavigation.ts
+++ b/src/lib/navigation/UINavigation.ts
@@ -19,6 +19,13 @@ const navigationLinkKeys: Record<NavigateBind, keyof ContainerNavigateOptions> =
     [Navigate.Up]       : "up",
 };
 
+const oppositeDirection: Partial<Record<NavigateBind, NavigateBind>> = {
+    [Navigate.Left]  : Navigate.Right,
+    [Navigate.Right] : Navigate.Left,
+    [Navigate.Up]    : Navigate.Down,
+    [Navigate.Down]  : Navigate.Up,
+};
+
 class NavigationManager
 {
     public static global = new NavigationManager();
@@ -46,8 +53,16 @@ class NavigationManager
              *
              * @default 2.5
              */
-            directionAxisWeight: 2.5,
-        } satisfies SpatialNavigationOptions,
+            directionAxisWeight: 10.0,
+
+            /**
+             * Whether backtracking is enabled (navigating immediately in
+             * the reverse direction takes you back to where you were).
+             *
+             * @default true
+             */
+            backtracking: true,
+        } as SpatialNavigationOptions,
 
         /**
          * FederatedPointerEvents to fire when navigating containers.
@@ -106,6 +121,8 @@ class NavigationManager
     private _rootContainer?: Container;
     private _rootFocused?: Container;
     private _clearBinds?: () => void;
+    private _backtrackSource: Container | undefined = undefined;
+    private _backtrackDirection: NavigateBind | undefined = undefined;
 
     private constructor()
     {}
@@ -207,7 +224,7 @@ class NavigationManager
         const previousResponder = this.firstResponder;
 
         this._responders.unshift(res);
-
+        this._clearBacktrack();
 
         previousResponder?.resignedAsFirstResponder?.();
         this._clearFocusTargetIfRemoved();
@@ -229,7 +246,7 @@ class NavigationManager
             previousResponder.focusTarget = undefined;
         }
 
-
+        this._clearBacktrack();
 
         const nextFocused = this.focusTarget;
 
@@ -272,6 +289,7 @@ class NavigationManager
 
         // Promote to top
         this._responders.unshift(res);
+        this._clearBacktrack();
 
         previousResponder?.resignedAsFirstResponder?.();
         this._clearFocusTargetIfRemoved();
@@ -317,6 +335,7 @@ class NavigationManager
         }
 
         const nextFocused = this.focusTarget;
+        this._clearBacktrack();
 
         // Only trigger lifecycle changes if first responder changed
         if (previousFirstResponder !== this.firstResponder)
@@ -379,10 +398,11 @@ class NavigationManager
 
     public disable(): void
     {
-
         this._clearNavigateBindsHandler();
         this._rootContainer = undefined;
         this._rootFocused = undefined;
+        this._backtrackSource = undefined;
+        this._backtrackDirection = undefined;
     }
 
     /**
@@ -400,6 +420,7 @@ class NavigationManager
         {
             this.focusSource = "pointer";
             this.device = undefined;
+            this._clearBacktrack();
         }
 
         const previous = this.focusTarget;
@@ -444,6 +465,12 @@ class NavigationManager
     }
 
     // ----- Implementation: -----
+
+    private _clearBacktrack(): void
+    {
+        this._backtrackSource = undefined;
+        this._backtrackDirection = undefined;
+    }
 
     private _clearNavigateBindsHandler(): void
     {
@@ -493,6 +520,7 @@ class NavigationManager
         {
             if (event.pressed)
             {
+                this._clearBacktrack();
                 this.setFocus(linkedContainer, device);
             }
 
@@ -502,12 +530,14 @@ class NavigationManager
         switch (bind)
         {
             case Navigate.Activate:
+                this._clearBacktrack();
                 if (event.pressed) this._press(focusTarget);
                 else this._release(focusTarget);
 
                 return;
 
             case Navigate.Back:
+                this._clearBacktrack();
                 if (event.pressed) return; // issue on releases only
 
                 this._blur(focusTarget);
@@ -516,6 +546,25 @@ class NavigationManager
 
             default: {
                 if (!event.pressed) return; // issue on presses only
+
+                if (this.options.spatial.backtracking)
+                {
+                    // backtrack: reverse the last spatial navigation step
+                    const backtrackSource = this._backtrackSource;
+                    const backtrackDirection = this._backtrackDirection;
+                    this._clearBacktrack();
+
+                    if (
+                        backtrackSource !== undefined
+                        && bind === oppositeDirection[backtrackDirection!]
+                        && backtrackSource.navigatable
+                    )
+                    {
+                        this.setFocus(backtrackSource, device);
+
+                        return;
+                    }
+                }
 
                 // spatial navigation
                 const stage = this.getStageContainer()!;
@@ -528,6 +577,12 @@ class NavigationManager
 
                 if (spatialTarget && spatialTarget !== focusTarget)
                 {
+                    if (this.options.spatial.backtracking)
+                    {
+                        this._backtrackSource = focusTarget;
+                        this._backtrackDirection = bind;
+                    }
+
                     this.setFocus(spatialTarget, event.device);
                 }
             }

--- a/src/lib/navigation/UINavigation.ts
+++ b/src/lib/navigation/UINavigation.ts
@@ -3,7 +3,7 @@ import { Container } from "pixi.js";
 import { Device, InputDevice, NamedBindEvent } from "../InputDevice";
 import { Navigate, type NavigateBind } from "./NavigateBind";
 import { NavigationResponder } from "./NavigationResponder";
-import { getFirstNavigatable, invalidateNavigatablesCache, isChildOf, SpatialNavigationOptions } from "./Navigatable";
+import { getFirstNavigatable, isChildOf, SpatialNavigationOptions } from "./Navigatable";
 import { emitPointerEvent } from "./emitPointerEvent";
 import { ContainerNavigateOptions } from "./ContainerNavigateOptions";
 
@@ -162,19 +162,6 @@ class NavigationManager
      * @param stageRoot - Root navigation responder container, where navigatable
      * containers can live.
      */
-    /**
-     * Manually invalidate the navigatable-list cache for the current stage.
-     *
-     * Call this after any structural change to the UI tree (adding/removing
-     * children, toggling visibility) so the next navigation query is accurate.
-     */
-    public invalidateNavCache(): void
-    {
-        const stage = this.getStageContainer();
-        if (stage) invalidateNavigatablesCache(stage);
-        else invalidateNavigatablesCache();
-    }
-
     public enable(stageRoot: Container): this
     {
         if (this.active)
@@ -185,7 +172,6 @@ class NavigationManager
 
         // enable stage
         this._rootContainer = stageRoot;
-        invalidateNavigatablesCache(stageRoot);
 
         // setup binds
         const handler = (e: NamedBindEvent<NavigateBind>): void =>
@@ -221,7 +207,7 @@ class NavigationManager
         const previousResponder = this.firstResponder;
 
         this._responders.unshift(res);
-        invalidateNavigatablesCache();
+
 
         previousResponder?.resignedAsFirstResponder?.();
         this._clearFocusTargetIfRemoved();
@@ -243,7 +229,7 @@ class NavigationManager
             previousResponder.focusTarget = undefined;
         }
 
-        invalidateNavigatablesCache();
+
 
         const nextFocused = this.focusTarget;
 
@@ -393,7 +379,7 @@ class NavigationManager
 
     public disable(): void
     {
-        invalidateNavigatablesCache();
+
         this._clearNavigateBindsHandler();
         this._rootContainer = undefined;
         this._rootFocused = undefined;


### PR DESCRIPTION
### What's changed?
- Removed navigation caching/manual invalidation - It's microseconds to do a DFS/BFS, and causes cache invalidation headaches.
- Add spatial navigation backtracking (going immediately Right/Left or Down/Up can take you where you previously were).

### Usage

```ts
UINavigation.options.spatial.backtrack = true; // default
```

To disable

```ts
UINavigation.options.spatial.backtrack = false;
```